### PR TITLE
Use correct path for home assistant config storage

### DIFF
--- a/stable/home-assistant/5.2.3/questions.yaml
+++ b/stable/home-assistant/5.2.3/questions.yaml
@@ -367,7 +367,7 @@ questions:
                 description: "Path inside the container the storage is mounted"
                 schema:
                   type: string
-                  default: "/usr/src/app/store"
+                  default: "/config"
                   hidden: true
               - variable: emptyDir
                 label: "EmptyDir Volume"


### PR DESCRIPTION
Currently Homeassistant loses all data upon pod restart because the wrong path is persisted to the PVC.

This adds the correct path.