### PR TITLE
Fix missing protocol for Omada Controller omda-udp3 service port

### DIFF
--- a/incubator/omada-controller/4.0.49/ix_values.yaml
+++ b/incubator/omada-controller/4.0.49/ix_values.yaml
@@ -62,6 +62,7 @@ service:
         targetPort: 29811
       omada-udp3:
         enabled: true
+        protocol: UDP
         port: 29812
         targetPort: 29812
       omada-udp4:


### PR DESCRIPTION
The Omada Controller omada-udp3 port spec was missing the protocol name. Added.