### PR TITLE
Will not validate catalog.json, since it does not exist

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           echo "Starting Catalog Validation"
-          python3 .catalog_validation/catalog_validation/scripts/catalog_validate.py validate --path "${PWD}"
+          python3 .catalog_validation/catalog_validation/scripts/catalog_validate.py validate --path "${PWD}" --ignore-catalog-json
 
       - name: catalog json generation
         shell: bash


### PR DESCRIPTION
**Requires https://github.com/truenas/catalog_validation/pull/61 to be merged**

**Description**
This will ignore the newly implemented validation of the catalog.json, since the file does not exist on the staging branch, yet.


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Ran script on my local machine

**📃 Notes:**
**Requires https://github.com/truenas/catalog_validation/pull/61 to be merged**