### PR TITLE
fix: adds tcp to fix rcon connection

### DIFF
--- a/stable/cs2/2.2.0/Chart.yaml
+++ b/stable/cs2/2.2.0/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/cs2
   - https://hub.docker.com/r/ich777/steamcmd
 type: application
-version: 2.2.0
+version: 2.2.1

--- a/stable/cs2/2.2.0/app-readme.md
+++ b/stable/cs2/2.2.0/app-readme.md
@@ -1,4 +1,12 @@
-A custom SteamCMD chart that runs CS2.
+A custom SteamCMD chart that runs a dedicated CS2 server.
+
+Easily setup a dedicated CS2 server.
+
+It's **highly recommened** to setup a RCon password.
+
+You can set various commandline options in the "Game params" section, see which ones is supported on the offial Valve [https://developer.valvesoftware.com/wiki/Command_line_options](documentation) website.
+
+
 
 This App is supplied by TrueCharts, for more information visit the manual: [https://truecharts.org/charts/stable/cs2](https://truecharts.org/charts/stable/cs2)
 

--- a/stable/cs2/2.2.0/ix_values.yaml
+++ b/stable/cs2/2.2.0/ix_values.yaml
@@ -12,8 +12,11 @@ securityContext:
 service:
   main:
     ports:
-      main:
+      main-udp:
         protocol: udp
+        port: 27015
+      main-tcp:
+        protocol: tcp
         port: 27015
 
 cs2:


### PR DESCRIPTION
**Description**
The RCon connection wont establish when the TCP port isn't listening
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I manually edited the deployed service to input the TCP port mapping, to confirm that is what is needed.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
